### PR TITLE
Integracao com API ViaCep para obter cidade pelo Cep

### DIFF
--- a/src/main/java/br/com/meli/apipartidafutebol/dto/EnderecoResponse.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/dto/EnderecoResponse.java
@@ -1,0 +1,36 @@
+package br.com.meli.apipartidafutebol.dto;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EnderecoResponse {
+    private String logradouro;
+    private String bairro;
+    private String localidade;
+    private String uf;
+
+    // Getters e setters
+    public String getLogradouro() {
+        return logradouro;
+    }
+    public void setLogradouro(String logradouro) {
+        this.logradouro = logradouro;
+    }
+    public String getBairro() {
+        return bairro;
+    }
+    public void setBairro(String bairro) {
+        this.bairro = bairro;
+    }
+    public String getLocalidade() {
+        return localidade;
+    }
+    public void setLocalidade(String localidade) {
+        this.localidade = localidade;
+    }
+    public String getUf() {
+        return uf;
+    }
+    public void setUf(String uf) {
+        this.uf = uf;
+    }
+}

--- a/src/main/java/br/com/meli/apipartidafutebol/dto/EstadioRequestDto.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/dto/EstadioRequestDto.java
@@ -1,10 +1,5 @@
 package br.com.meli.apipartidafutebol.dto;
-
 import jakarta.validation.constraints.*;
-
-import java.time.LocalDate;
-
-
 public class EstadioRequestDto {
     @NotBlank(message = "O nome do estádio é obrigatório.")
     @Size(min = 2, message = "O nome deve ter pelo menos 2 caracteres.")
@@ -16,47 +11,51 @@ public class EstadioRequestDto {
     private Integer capacidade;
     @NotNull(message = "O campo 'ativo' é obrigatório.")
     private Boolean ativo;
+    @NotBlank(message = "O CEP é obrigatório.")
+    @Pattern(regexp = "\\d{8}", message = "O CEP deve conter exatamente 8 dígitos numéricos.")
+    private String cep;
 
-    public EstadioRequestDto(String nome, String cidade, Integer capacidade, Boolean ativo) {
+
+    // Construtor
+    public EstadioRequestDto(String nome, String cidade, Integer capacidade, Boolean ativo, String cep) {
         this.nome = nome;
         this.cidade = cidade;
         this.capacidade = capacidade;
         this.ativo = ativo;
+        this.cep = cep;
     }
+    public EstadioRequestDto() {
 
-
+    }
     // Getters e Setters
-
-
     public String getNome() {
         return nome;
     }
-
     public void setNome(String nome) {
         this.nome = nome;
     }
-
     public String getCidade() {
         return cidade;
     }
-
     public void setCidade(String cidade) {
         this.cidade = cidade;
     }
-
     public Integer getCapacidade() {
         return capacidade;
     }
-
     public void setCapacidade(Integer capacidade) {
         this.capacidade = capacidade;
     }
-
     public Boolean getAtivo() {
         return ativo;
     }
-
     public void setAtivo(Boolean ativo) {
         this.ativo = ativo;
+    }
+    public String getCep() {
+        return cep;
+    }
+    public void setCep(String cep) {
+        this.cep = cep;
     }
 }

--- a/src/main/java/br/com/meli/apipartidafutebol/dto/EstadioResponseDto.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/dto/EstadioResponseDto.java
@@ -1,20 +1,25 @@
 package br.com.meli.apipartidafutebol.dto;
 
 import br.com.meli.apipartidafutebol.model.Estadio;
+
+import java.util.UUID;
+
 public class EstadioResponseDto {
     private Long id;
     private String nome;
     private String cidade;
     private Integer capacidade;
     private Boolean ativo;
+    private String cep;
 
     // Construtor completo
-    public EstadioResponseDto(Long id, String nome, String cidade, Integer capacidade, Boolean ativo) {
+    public EstadioResponseDto(Long id, String nome, String cidade, Integer capacidade, Boolean ativo, String cep) {
         this.id = id;
         this.nome = nome;
         this.cidade = cidade;
         this.capacidade = capacidade;
         this.ativo = ativo;
+        this.cep = cep;
     }
     // Construtor que recebe a entidade Estadio
     public EstadioResponseDto(Estadio estadio) {
@@ -23,7 +28,8 @@ public class EstadioResponseDto {
                 estadio.getNome(),
                 estadio.getCidade(),
                 estadio.getCapacidade(),
-                estadio.getAtivo()
+                estadio.getAtivo(),
+                estadio.getCep()
         );
     }
 
@@ -32,21 +38,53 @@ public class EstadioResponseDto {
     }
 
     // Getters
-    public Long getId() {
-        return id;
-    }
-    public String getNome() {
-        return nome;
-    }
-    public String getCidade() {
-        return cidade;
-    }
-    public Integer getCapacidade() {
-        return capacidade;
-    }
+
+
     public Boolean getAtivo() {
         return ativo;
     }
 
+    public void setAtivo(Boolean ativo) {
+        this.ativo = ativo;
+    }
 
+    public Integer getCapacidade() {
+        return capacidade;
+    }
+
+    public void setCapacidade(Integer capacidade) {
+        this.capacidade = capacidade;
+    }
+
+    public String getCep() {
+        return cep;
+    }
+
+    public void setCep(String cep) {
+        this.cep = cep;
+    }
+
+    public String getCidade() {
+        return cidade;
+    }
+
+    public void setCidade(String cidade) {
+        this.cidade = cidade;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
 }

--- a/src/main/java/br/com/meli/apipartidafutebol/exception/CepNaoEncontradoException.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/exception/CepNaoEncontradoException.java
@@ -1,0 +1,7 @@
+package br.com.meli.apipartidafutebol.exception;
+
+public class CepNaoEncontradoException extends RuntimeException {
+    public CepNaoEncontradoException(String message) {
+        super("CEP não encontrado ou inválido "+ message);
+    }
+}

--- a/src/main/java/br/com/meli/apipartidafutebol/exception/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/exception/GlobalExceptionHandler.java
@@ -48,11 +48,16 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(new ErrorResponseDto(HttpStatus.NOT_FOUND.name(), ex.getMessage()));
     }
-    // Fallback genérico
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponseDto> handleException(Exception ex) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ErrorResponseDto("ERRO_INTERNO", "Erro inesperado: " + ex.getMessage()));
+    }
+    @ExceptionHandler(CepNaoEncontradoException.class)
+    public ResponseEntity<ErrorResponseDto> handleCepNaoEncontrado(CepNaoEncontradoException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponseDto(HttpStatus.BAD_REQUEST.name(), ex.getMessage()));
     }
 }
 

--- a/src/main/java/br/com/meli/apipartidafutebol/integration/ViaCepClient.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/integration/ViaCepClient.java
@@ -1,0 +1,24 @@
+package br.com.meli.apipartidafutebol.integration;
+import br.com.meli.apipartidafutebol.dto.EnderecoResponse;
+import br.com.meli.apipartidafutebol.exception.CepNaoEncontradoException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+@Component
+public class ViaCepClient {
+    private static final String VIA_CEP_URL = "https://viacep.com.br/ws/{cep}/json/";
+    private final RestTemplate restTemplate = new RestTemplate();
+    public EnderecoResponse buscarEnderecoPorCep(String cep) {
+        cep = cep.replaceAll("[^0-9]", ""); // limpa o CEP
+        String url = UriComponentsBuilder.fromUriString(VIA_CEP_URL)
+                .buildAndExpand(cep)
+                .toUriString();
+        EnderecoResponse endereco = restTemplate.getForObject(url, EnderecoResponse.class);
+        if (endereco == null || endereco.getLocalidade() == null || endereco.getUf() == null) {
+            {
+                throw new CepNaoEncontradoException("CEP inválido ou não encontrado.");
+            }
+        }
+        return endereco;
+    }
+}

--- a/src/main/java/br/com/meli/apipartidafutebol/model/Estadio.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/model/Estadio.java
@@ -3,62 +3,87 @@ package br.com.meli.apipartidafutebol.model;
 import jakarta.persistence.*;
 
 @Entity
-    @Table(name = "estadios")
-    public class Estadio {
-        @Id
-        @GeneratedValue(strategy = GenerationType.IDENTITY)
-        private Long id;
-        @Column(nullable = false, length = 100)
-        private String nome;
-        @Column(nullable = false, length = 100)
-        private String cidade;
-        @Column(nullable = false)
-        private Integer capacidade;
-        @Column(nullable = false)
-        private Boolean ativo;
-        // Construtores
-        public Estadio() {}
-        public Estadio(String nome, String cidade, Integer capacidade, Boolean ativo) {
-            this.nome = nome;
-            this.cidade = cidade;
-            this.capacidade = capacidade;
-            this.ativo = ativo;
-        }
+@Table(name = "estadios")
+public class Estadio {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false, length = 100)
+    private String nome;
+    @Column(nullable = false, length = 100)
+    private String cidade;
+    @Column(nullable = false)
+    private Integer capacidade;
+    @Column(nullable = false)
+    private Boolean ativo;
+    @Column(length = 9)
+    private String cep;
+    @Column(length = 100)
+    private String logradouro;
+    @Column(length = 100)
+    private String bairro;
+    @Column(length = 2)
+    private String uf;
 
-    public Estadio(String maracanã, String rj, int i) {
+    // Construtores
+    public Estadio() {
     }
 
+    public Estadio(String nome, String cidade, Integer capacidade, Boolean ativo,String cep) {
+        this.nome = nome;
+        this.cidade = cidade;
+        this.capacidade = capacidade;
+        this.ativo = ativo;
+        this.cep = cep;
+    }
 
     // Getters e Setters
-        public Long getId() {
-            return id;
-        }
-        public String getNome() {
-            return nome;
-        }
-        public void setNome(String nome) {
-            this.nome = nome;
-        }
-        public String getCidade() {
-            return cidade;
-        }
-        public void setCidade(String cidade) {
-            this.cidade = cidade;
-        }
-        public Integer getCapacidade() {
-            return capacidade;
-        }
-        public void setCapacidade(Integer capacidade) {
-            this.capacidade = capacidade;
-        }
-        public Boolean getAtivo() {
-            return ativo;
-        }
-        public void setAtivo(Boolean ativo) {
-            this.ativo = ativo;
-        }
+    public Long getId() {
+        return id;
+    }
 
     public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getCidade() {
+        return cidade;
+    }
+
+    public void setCidade(String cidade) {
+        this.cidade = cidade;
+    }
+
+    public Integer getCapacidade() {
+        return capacidade;
+    }
+
+    public void setCapacidade(Integer capacidade) {
+        this.capacidade = capacidade;
+    }
+
+    public Boolean getAtivo() {
+        return ativo;
+    }
+
+    public void setAtivo(Boolean ativo) {
+        this.ativo = ativo;
+    }
+
+    public String getCep() {
+        return cep;
+    }
+
+    public void setCep(String cep) {
+        this.cep = cep;
     }
 }
 

--- a/src/test/java/br/com/meli/apipartidafutebol/controller/EstadioControllerTest.java
+++ b/src/test/java/br/com/meli/apipartidafutebol/controller/EstadioControllerTest.java
@@ -26,7 +26,7 @@ class EstadioControllerTest {
 
     @Test
     void cadastrar() throws Exception {
-        EstadioRequestDto request = new EstadioRequestDto("Arena Teste", "São Paulo", 50000, true);
+        EstadioRequestDto request = new EstadioRequestDto("Arena Teste", "São Paulo", 50000, true,"00000000");
         EstadioResponseDto response = new EstadioResponseDto();
         Mockito.when(estadioService.salvar(any())).thenReturn(response);
         mockMvc.perform(post("/estadios")
@@ -51,7 +51,7 @@ class EstadioControllerTest {
 
     @Test
     void atualizar() throws Exception {
-        EstadioRequestDto request = new EstadioRequestDto("Novo Nome", "Rio de Janeiro", 60000, true);
+        EstadioRequestDto request = new EstadioRequestDto("Novo Nome", "Rio de Janeiro", 60000, true,"00000000");
         EstadioResponseDto response = new EstadioResponseDto();
         Mockito.when(estadioService.atualizar(Mockito.eq(1L), any())).thenReturn(response);
         mockMvc.perform(put("/estadios/1")

--- a/src/test/java/br/com/meli/apipartidafutebol/service/EstadioServiceTest.java
+++ b/src/test/java/br/com/meli/apipartidafutebol/service/EstadioServiceTest.java
@@ -23,9 +23,9 @@ class EstadioServiceTest {
     }
     @Test
     void salvar_DeveRetornarEstadioResponseDto_QuandoSucesso() {
-        EstadioRequestDto dto = new EstadioRequestDto("Maracana", "RJ", 80000, true
+        EstadioRequestDto dto = new EstadioRequestDto("Maracana", "RJ", 80000, true,"00000000"
                 );
-        Estadio estadioSalvo = new Estadio("Maracana", "RJ", 80000, true);
+        Estadio estadioSalvo = new Estadio("Maracana", "RJ", 80000, true,"00000000");
         estadioSalvo.setId(1L); // :marca_de_verificação_branca: necessário para o DTO
         when(estadioRepository.save(any(Estadio.class))).thenReturn(estadioSalvo);
         EstadioResponseDto response = estadioService.salvar(dto);
@@ -38,8 +38,8 @@ class EstadioServiceTest {
     @Test
     void listarTodos_DeveRetornarListaDeEstadios() {
         List<Estadio> estadios = List.of(
-                new Estadio("Maracanã", "RJ", 80000, true),
-                new Estadio("Morumbi", "SP", 67000, true)
+                new Estadio("Maracanã", "RJ", 80000, true,"00000000"),
+                new Estadio("Morumbi", "SP", 67000, true,"00000000")
         );
         when(estadioRepository.findAll()).thenReturn(estadios);
         List<EstadioResponseDto> resultado = estadioService.listarTodos();
@@ -50,7 +50,7 @@ class EstadioServiceTest {
     }
     @Test
     void buscarPorId_DeveRetornarEstadioResponseDto_QuandoEncontrado() {
-        Estadio estadio = new Estadio("Maracanã", "RJ", 80000, true);
+        Estadio estadio = new Estadio("Maracanã", "RJ", 80000, true,"00000000");
         estadio.setId(1L);
         when(estadioRepository.findById(1L)).thenReturn(Optional.of(estadio));
         EstadioResponseDto response = estadioService.buscarPorId(1L);
@@ -65,8 +65,8 @@ class EstadioServiceTest {
     @Test
     void atualizar_DeveRetornarEstadioAtualizado() {
         Long id = 1L;
-        EstadioRequestDto dto = new EstadioRequestDto("Novo Maracanã", "RJ", 75000, true);
-        Estadio estadioExistente = new Estadio("Maracanã", "RJ", 80000, true);
+        EstadioRequestDto dto = new EstadioRequestDto("Novo Maracanã", "RJ", 75000, true,"00000000");
+        Estadio estadioExistente = new Estadio("Maracanã", "RJ", 80000, true,"00000000");
         estadioExistente.setId(id);
         when(estadioRepository.findById(id)).thenReturn(Optional.of(estadioExistente));
         when(estadioRepository.save(any(Estadio.class))).thenAnswer(invocation -> {
@@ -84,7 +84,7 @@ class EstadioServiceTest {
     void deletar_DeveRemoverEstadio_QuandoIdExistente() {
         Long id = 1L;
         Estadio estadio = new Estadio("Maracanã", "RJ", 80000,
-                true);
+                true,"00000000");
         when(estadioRepository.findById(id)).thenReturn(Optional.of(estadio));
         doNothing().when(estadioRepository).delete(estadio);
         estadioService.deletar(id);

--- a/src/test/java/br/com/meli/apipartidafutebol/service/PartidaServiceTest.java
+++ b/src/test/java/br/com/meli/apipartidafutebol/service/PartidaServiceTest.java
@@ -41,7 +41,7 @@ class PartidaServiceTest {
         Clube visitante = new Clube("Clube B", "RJ",
                 LocalDate.of(2000, 1, 1), true);
         visitante.setId(2L);
-        Estadio estadio = new Estadio("Arena", "SP", 50000, true);
+        Estadio estadio = new Estadio("Arena", "SP", 50000, true,"00000000");
         estadio.setId(3L);
         Partida partida = new Partida(mandante, visitante, estadio, dataHora, 1, 2);
         partida.setId(10L);
@@ -69,7 +69,7 @@ class PartidaServiceTest {
         mandante.setId(1L);
         Clube visitante = new Clube("Clube B", "RJ", LocalDate.of(2000, 1, 1), true);
         visitante.setId(2L);
-        Estadio estadio = new Estadio("Arena", "SP", 50000, true);
+        Estadio estadio = new Estadio("Arena", "SP", 50000, true,"00000000");
         estadio.setId(3L);
         Partida partida = new Partida(
                 mandante, visitante, estadio,
@@ -91,7 +91,7 @@ class PartidaServiceTest {
         mandante.setId(1L);
         Clube visitante = new Clube("Clube B", "RJ", LocalDate.of(2000, 1, 1), true);
         visitante.setId(2L);
-        Estadio estadio = new Estadio("Arena", "SP", 50000, true);
+        Estadio estadio = new Estadio("Arena", "SP", 50000, true,"00000000");
         estadio.setId(3L);
         Partida partida1 = new Partida(mandante, visitante, estadio,
                 LocalDateTime.of(2025, 7, 20, 18, 0), 2, 2);
@@ -128,7 +128,7 @@ class PartidaServiceTest {
         Clube visitante = new Clube("Clube B", "RJ",
                 LocalDate.of(2000, 1, 1), true);
         visitante.setId(2L);
-        Estadio estadio = new Estadio("Arena", "SP", 50000, true);
+        Estadio estadio = new Estadio("Arena", "SP", 50000, true,"00000000");
         estadio.setId(3L);
         Partida partida = new Partida(mandante, visitante, estadio,
                 dataHora.minusDays(1), 0, 0);


### PR DESCRIPTION
### Objetivo
Este PR implementa a integração com a API pública ViaCep para preencher automaticamente o campo "cidade" ao cadastrar um novo estádio, a partir do CEP informado.
---
### Alterações realizadas
:marca_de_verificação_branca: **Nova camada de integração**
- Criado o pacote `integration` para organização de chamadas externas
- Criada a classe `ViaCepClient` usando `RestTemplate` para consumo da API https://viacep.com.br/
:marca_de_verificação_branca: **DTOs**
- `EstadioRequestDto`: adicionado o campo `cep`, com validações:
  - `@NotBlank`
  - `@Pattern(regexp = "\\d{8}")` (apenas dígitos numéricos, 8 posições)
- `EstadioResponseDto`: adicionado campo `cep` para retorno completo ao cliente
:marca_de_verificação_branca: **Model**
- `Estadio`: adicionada propriedade `cep` com getter e setter
:marca_de_verificação_branca: **Service**
- `EstadioService`: no método `salvar`, o CEP informado é:
  - Validado (regex)
  - Consultado na API ViaCep
  - Usado para preencher o campo `cidade` automaticamente
  - Lançadas exceções customizadas para CEP inválido ou não encontrado
:marca_de_verificação_branca: **Exceptions**
- Criada `CepNaoEncontradoException`
- Registrada no `GlobalExceptionHandler` com retorno HTTP 400 e mensagem amigável
:marca_de_verificação_branca: **Controller**
- `EstadioController`: permanece com lógica limpa, delegando ao service
- Swagger documentado normalmente
---
### Testes manuais
- Testado com POST válido via Postman
- Testado com CEP inválido e erro customizado
- Testado com CEP com hífen (`20770-001`) e sem hífen (`20770001`)
---
### Considerações
- A nova camada `integration` permite reutilização futura com outras APIs externas
- Validação e encapsulamento respeitam o padrão já existente no projeto
---
### Próximos passos (futuros)
- Criar testes unitários com mock da chamada ViaCep
- Considerar uso de cache para CEPs já buscados (opcional)

viacep.com.brviacep.com.br
[ViaCEP - Webservice CEP e IBGE gratuito](https://viacep.com.br/)
Webservice gratuito para consulta de endereço via CEP, suporta Ajax e retorno nos formatos JSON ou XML.