### PR TITLE
feat(kafka): integracao com kafka para publicar consumir mensagens de…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,57 @@
+
+
+services:
+  # :bússola: Zookeeper
+  zookeeper:
+    image: zookeeper:3.8
+    container_name: zookeeper
+    restart: always
+    ports:
+      - "2181:2181"
+  # :email: Kafka com listeners internos + externos
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    container_name: kafka
+    restart: always
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://kafka:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_INTERNAL://0.0.0.0:29092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT_INTERNAL
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_LOG_RETENTION_MS: 600000
+    depends_on:
+      - zookeeper
+  # :globo_com_meridianos: Kafdrop - interface web
+  kafdrop:
+    image: obsidiandynamics/kafdrop
+    container_name: kafdrop
+    restart: always
+    ports:
+      - "9000:9000"
+    environment:
+      KAFKA_BROKER_CONNECT: kafka:29092
+    depends_on:
+      - kafka
+volumes:
+  mysql-data:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
         <!-- Documentação OpenAPI -->
         <dependency>
             <groupId>org.springdoc</groupId>
@@ -59,6 +64,10 @@
             <artifactId>mockito-core</artifactId>
             <version>5.10.0</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/br/com/meli/apipartidafutebol/ApiPartidaFutebolApplication.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/ApiPartidaFutebolApplication.java
@@ -2,7 +2,9 @@ package br.com.meli.apipartidafutebol;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.kafka.annotation.EnableKafka;
 
+@EnableKafka
 @SpringBootApplication
 public class ApiPartidaFutebolApplication {
 

--- a/src/main/java/br/com/meli/apipartidafutebol/config/JacksonConfig.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/config/JacksonConfig.java
@@ -1,0 +1,15 @@
+package br.com.meli.apipartidafutebol.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+@Configuration
+public class JacksonConfig {
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        return mapper;
+    }
+}

--- a/src/main/java/br/com/meli/apipartidafutebol/consumer/PartidaConsumer.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/consumer/PartidaConsumer.java
@@ -1,0 +1,37 @@
+package br.com.meli.apipartidafutebol.consumer;
+
+import br.com.meli.apipartidafutebol.dto.PartidaRequestDto;
+import br.com.meli.apipartidafutebol.service.PartidaService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PartidaConsumer {
+    private final PartidaService partidaService;
+    private final ObjectMapper objectMapper;
+    public PartidaConsumer(PartidaService partidaService, ObjectMapper objectMapper) {
+        this.partidaService = partidaService;
+        this.objectMapper = objectMapper;
+    }
+    @KafkaListener(
+            id = "listener-partida",
+            topics = "${spring.kafka.topic.partida}",
+            groupId = "${spring.kafka.consumer.group-id}"
+    )
+    public void consumir(ConsumerRecord<String, String> record) {
+        try {
+            // Espera de 5 segundos para visualização da mensagem no Kafdrop
+            System.out.println(" Aguardando antes de processar mensagem...");
+            Thread.sleep(5000);
+            String mensagemJson = record.value();
+            System.out.println(" Mensagem recebida do Kafka: " + mensagemJson);
+            PartidaRequestDto dto = objectMapper.readValue(mensagemJson, PartidaRequestDto.class);
+            partidaService.salvar(dto);
+        } catch (Exception e) {
+            System.err.println(" Erro ao processar mensagem do Kafka: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/br/com/meli/apipartidafutebol/dto/PartidaRequestDto.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/dto/PartidaRequestDto.java
@@ -1,5 +1,6 @@
 package br.com.meli.apipartidafutebol.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.*;
 import java.time.LocalDateTime;
@@ -11,6 +12,7 @@ public class PartidaRequestDto {
     @NotNull(message = "O ID do estádio é obrigatório.")
     private Long estadioId;
     @NotNull(message = "A data e hora da partida são obrigatórias.")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     @JsonProperty("dataHora")
     private LocalDateTime dataHora;
     private Integer placarMandante;
@@ -26,6 +28,9 @@ public class PartidaRequestDto {
         this.placarVisitante = placarVisitante;
     }
 
+    public PartidaRequestDto() {
+
+    }
 
     // Getters e Setters
     public Long getClubeMandanteId() {

--- a/src/main/java/br/com/meli/apipartidafutebol/integration/PartidaProducer.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/integration/PartidaProducer.java
@@ -1,0 +1,36 @@
+package br.com.meli.apipartidafutebol.integration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+
+
+@Service
+public class PartidaProducer {
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    @Value("${spring.kafka.topic.partida}")
+    private String topicName;
+    public PartidaProducer(KafkaTemplate<String, String> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+    public void enviarMensagem(String mensagemJson) {
+        String mensagemId= UUID.randomUUID().toString();
+        System.out.println(" Producer Enviando mensagem ID para o tópico: "+ mensagemId + " -> " + mensagemJson);
+        CompletableFuture<?> future = kafkaTemplate.send(topicName, mensagemJson);
+        future.whenComplete( (       result ,ex) -> {
+            if (ex != null) {
+                System.out.println(" Producer Mensagem ID " + mensagemId + "Mensagem enviada com sucesso Kafka: " );
+            } else {
+                System.out.println(" Producer Falha ao enviar Mensagem ID " + mensagemId + ": " + ex.getMessage());
+            }
+
+
+
+    });
+
+        }
+    }

--- a/src/main/java/br/com/meli/apipartidafutebol/validator/PartidaValidator.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/validator/PartidaValidator.java
@@ -1,0 +1,28 @@
+package br.com.meli.apipartidafutebol.validator;
+
+import br.com.meli.apipartidafutebol.dto.PartidaRequestDto;
+import org.springframework.stereotype.Component;
+@Component
+public class PartidaValidator {
+    public void validar(PartidaRequestDto dto) {
+        if (dto.getClubeMandanteId().equals(dto.getClubeVisitanteId())) {
+            throw new IllegalArgumentException("Os clubes da partida devem ser diferentes.");
+        }
+        // Exemplo adicional: se quiser validar data no futuro
+        /*
+        if (dto.getDataPartida().isBefore(LocalDate.now())) {
+            throw new IllegalArgumentException("A data da partida deve ser futura.");
+        }
+        */
+    }
+}
+
+
+
+
+
+
+
+
+
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 spring.application.name=api-partida-futebol
 
+
 spring.datasource.url=jdbc:mysql://localhost:3306/futebol?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
 spring.datasource.username=root
 spring.datasource.password=123456
@@ -11,3 +12,13 @@ spring.datasource.hikari.maximum-pool-size=5
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+
+spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.topic.partida=cadastro-partida
+spring.kafka.consumer.group-id=grupo-partida
+spring.kafka.consumer.auto-offset-reset=earliest
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.retries=0

--- a/src/test/java/br/com/meli/apipartidafutebol/controller/ClubeControllerTest.java
+++ b/src/test/java/br/com/meli/apipartidafutebol/controller/ClubeControllerTest.java
@@ -39,6 +39,7 @@ class ClubeControllerTest {
                 .andExpect(jsonPath("$.nome").value("Time Teste"))
                 .andExpect(jsonPath("$.siglaEstado").value("SP"))
                 .andExpect(jsonPath("$.ativo").value(true));
+
     }
     @Test
     void deveListarTodosClubes() throws Exception {


### PR DESCRIPTION
Este PR implementa a comunicação assíncrona entre a API de partidas e o Apache Kafka.


Alterações principais:

- Criação da classe PartidaProducer responsável por serializar e publicar mensagens JSON no tópico Kafka (cadastro-partida).

- Criação da classe PartidaConsumer que escuta o tópico Kafka e salva as partidas no banco de dados após consumir a mensagem.
 
- Novo endpoint POST /partidas/publicar na PartidaController, que valida os dados e envia para o Kafka sem persistir 
diretamente.
- Endpoint POST /partidas/salvar permanece como opção síncrona para testes diretos no banco.

- Adicionada a dependência jackson-datatype-jsr310 para permitir a serialização/deserialização correta do tipo 
 LocalDateTime.

- Atualização do application.properties com configurações de producer, consumer, e topic.

- Arquivo docker-compose.yml incluído com containers para zookeeper, kafka e kafdrop para monitoramento visual.

 Observação:
- Kafdrop pode exibir mensagens duplicadas visualmente por conta do offset e histórico no tópico, mas o consumo real acontece uma única vez conforme validado no terminal.

- Validações de regras de negócio ainda são feitas no consumidor antes de persistir a partida no banco.
