### PR TITLE
feat(kafka)retries aplication proporties,para topico DLT e consumo as…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,11 +41,6 @@
             <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-        </dependency>
-
         <!-- Documentação OpenAPI -->
         <dependency>
             <groupId>org.springdoc</groupId>

--- a/src/main/java/br/com/meli/apipartidafutebol/config/KafkaConsumerConfig.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/config/KafkaConsumerConfig.java
@@ -1,0 +1,45 @@
+package br.com.meli.apipartidafutebol.config;
+import br.com.meli.apipartidafutebol.exception.DataInvalidaException;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.ExponentialBackOffWithMaxRetries;
+
+@Configuration
+public class KafkaConsumerConfig {
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+            ConsumerFactory<String, String> consumerFactory,
+            DefaultErrorHandler errorHandler) {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+        factory.setCommonErrorHandler(errorHandler); // Aplica o handler no listener
+        return factory;
+    }
+    @Bean
+    public DefaultErrorHandler errorHandler(KafkaTemplate<String, String> kafkaTemplate) {
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
+                kafkaTemplate,
+                (record, ex) -> {
+                    String dltTopic = record.topic() + ".DLT";
+                    System.out.println(" Enviando para DLT: " + dltTopic);
+                    return new org.apache.kafka.common.TopicPartition(dltTopic, record.partition());
+                }
+        );
+        ExponentialBackOffWithMaxRetries backOff = new ExponentialBackOffWithMaxRetries(3);
+        backOff.setInitialInterval(2000);
+        backOff.setMultiplier(2.0);
+        backOff.setMaxInterval(10000);
+        DefaultErrorHandler handler = new DefaultErrorHandler(recoverer, backOff);
+        handler.addNotRetryableExceptions(DataInvalidaException.class);
+        handler.setRetryListeners((record, ex, deliveryAttempt) -> {
+            System.err.println(" Tentativa #" + deliveryAttempt + " falhou para mensagem: " + record.value());
+        });
+        return handler;
+    }
+}

--- a/src/main/java/br/com/meli/apipartidafutebol/consumer/PartidaConsumer.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/consumer/PartidaConsumer.java
@@ -2,6 +2,7 @@ package br.com.meli.apipartidafutebol.consumer;
 
 import br.com.meli.apipartidafutebol.dto.PartidaRequestDto;
 import br.com.meli.apipartidafutebol.service.PartidaService;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -20,18 +21,33 @@ public class PartidaConsumer {
             topics = "${spring.kafka.topic.partida}",
             groupId = "${spring.kafka.consumer.group-id}"
     )
-    public void consumir(ConsumerRecord<String, String> record) {
-        try {
-            // Espera de 5 segundos para visualização da mensagem no Kafdrop
-            System.out.println(" Aguardando antes de processar mensagem...");
-            Thread.sleep(5000);
-            String mensagemJson = record.value();
-            System.out.println(" Mensagem recebida do Kafka: " + mensagemJson);
-            PartidaRequestDto dto = objectMapper.readValue(mensagemJson, PartidaRequestDto.class);
-            partidaService.salvar(dto);
-        } catch (Exception e) {
-            System.err.println(" Erro ao processar mensagem do Kafka: " + e.getMessage());
-            e.printStackTrace();
-        }
+    public void consumir(ConsumerRecord<String, String> record){
+    try {
+        // Espera de 5 segundos para visualização da mensagem no Kafdrop
+        System.out.println(" Aguardando antes de processar mensagem...");
+        Thread.sleep(5000);
+        String mensagemJson = record.value();
+        System.out.println(" Mensagem recebida no Kafka: " + mensagemJson);
+        PartidaRequestDto dto = objectMapper.readValue(mensagemJson, PartidaRequestDto.class);
+        partidaService.salvar(dto);
+        System.out.println("Partida processada com sucesso e salva no banco de dados");
+    } catch (Exception e) {
+        System.err.println(" Erro ao processar mensagem do kafka: ! " + e.getMessage());
+        throw new RuntimeException(e);
+
     }
+
+
+    }
+    @KafkaListener(topics = "${spring.kafka.topic.partida}.DLT", groupId = "grupo-partida-dlt")
+    public void consumirDlt(String mensagem) {
+        System.err.println(" Atenção Mensagem falhou e foi enviada para a DLT: " + mensagem);
+    }
+
+
+
+
+
+
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,6 +15,7 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 
 spring.kafka.bootstrap-servers=localhost:9092
 spring.kafka.topic.partida=cadastro-partida
+spring.kafka.topic.partida.dlt=cadastro-partida.DLT
 spring.kafka.consumer.group-id=grupo-partida
 spring.kafka.consumer.auto-offset-reset=earliest
 spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer


### PR DESCRIPTION
…sincrono de partida com validacao

- Envio de mensagens JSON de partidas para tópico `cadastro-partida` via Kafka.
- Consumer com validação de regras de negócio antes de persistir no banco.
- Configuração de `DefaultErrorHandler` com 3 tentativas e backoff exponencial.
- Redirecionamento automático para `cadastro-partida.DLT` em caso de falha (ex: DataInvalidaException).
- Tópicos com retenção de 1 minuto.
- Log completo em console com feedback de sucesso e falha.


1. POST válido em `/partidas/publicar` → deve salvar e logar sucesso.
2. POST inválido (ex: data passada) → falha 3x e envia mensagem vai para a DLT.
3. Acompanhar mensagens no Kafdrop.






