### PR TITLE
feat(kafka): Implementa retentativas automaticas com DLT e endpoint d…

### DIFF
--- a/src/main/java/br/com/meli/apipartidafutebol/config/KafkaConsumerConfig.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/config/KafkaConsumerConfig.java
@@ -14,32 +14,30 @@ public class KafkaConsumerConfig {
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
             ConsumerFactory<String, String> consumerFactory,
-            DefaultErrorHandler errorHandler) {
+            DefaultErrorHandler errorHandler
+    ) {
         ConcurrentKafkaListenerContainerFactory<String, String> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory);
-        factory.setCommonErrorHandler(errorHandler); // Aplica o handler no listener
+        factory.setCommonErrorHandler(errorHandler);
         return factory;
     }
     @Bean
     public DefaultErrorHandler errorHandler(KafkaTemplate<String, String> kafkaTemplate) {
-        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
-                kafkaTemplate,
-                (record, ex) -> {
-                    String dltTopic = record.topic() + ".DLT";
-                    System.out.println(" Enviando para DLT: " + dltTopic);
-                    return new org.apache.kafka.common.TopicPartition(dltTopic, record.partition());
-                }
-        );
+        // Redireciona para a DLT após falha
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(kafkaTemplate);
+        // Retry com backoff: 3 tentativas, começando com 3s e dobrando
         ExponentialBackOffWithMaxRetries backOff = new ExponentialBackOffWithMaxRetries(3);
-        backOff.setInitialInterval(2000);
+        backOff.setInitialInterval(3000);
         backOff.setMultiplier(2.0);
-        backOff.setMaxInterval(10000);
-        DefaultErrorHandler handler = new DefaultErrorHandler(recoverer, backOff);
-        handler.addNotRetryableExceptions(DataInvalidaException.class);
-        handler.setRetryListeners((record, ex, deliveryAttempt) -> {
-            System.err.println(" Tentativa #" + deliveryAttempt + " falhou para mensagem: " + record.value());
+        backOff.setMaxInterval(20000);
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, backOff);
+        // Apenas erros de negócio vão direto para a DLT
+        errorHandler.addNotRetryableExceptions(DataInvalidaException.class);
+        // Log para cada tentativa
+        errorHandler.setRetryListeners((record, ex, attempt) -> {
+            System.err.println("repetir Tentativa " + attempt + " falhou: " + record.value());
         });
-        return handler;
+        return errorHandler;
     }
 }

--- a/src/main/java/br/com/meli/apipartidafutebol/consumer/PartidaConsumer.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/consumer/PartidaConsumer.java
@@ -1,8 +1,8 @@
 package br.com.meli.apipartidafutebol.consumer;
 
 import br.com.meli.apipartidafutebol.dto.PartidaRequestDto;
+import br.com.meli.apipartidafutebol.integration.PartidaProducer;
 import br.com.meli.apipartidafutebol.service.PartidaService;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -12,42 +12,50 @@ import org.springframework.stereotype.Component;
 public class PartidaConsumer {
     private final PartidaService partidaService;
     private final ObjectMapper objectMapper;
-    public PartidaConsumer(PartidaService partidaService, ObjectMapper objectMapper) {
+    private final PartidaProducer partidaProducer;
+    public PartidaConsumer(PartidaService partidaService,
+                           ObjectMapper objectMapper,
+                           PartidaProducer partidaProducer) {
         this.partidaService = partidaService;
         this.objectMapper = objectMapper;
+        this.partidaProducer = partidaProducer;
     }
     @KafkaListener(
             id = "listener-partida",
             topics = "${spring.kafka.topic.partida}",
             groupId = "${spring.kafka.consumer.group-id}"
     )
-    public void consumir(ConsumerRecord<String, String> record){
-    try {
-        // Espera de 5 segundos para visualização da mensagem no Kafdrop
-        System.out.println(" Aguardando antes de processar mensagem...");
-        Thread.sleep(5000);
+    public void consumir(ConsumerRecord<String, String> record) throws Exception {
         String mensagemJson = record.value();
-        System.out.println(" Mensagem recebida no Kafka: " + mensagemJson);
-        PartidaRequestDto dto = objectMapper.readValue(mensagemJson, PartidaRequestDto.class);
-        partidaService.salvar(dto);
-        System.out.println("Partida processada com sucesso e salva no banco de dados");
-    } catch (Exception e) {
-        System.err.println(" Erro ao processar mensagem do kafka: ! " + e.getMessage());
-        throw new RuntimeException(e);
-
+        System.out.println(" Caixa de entrada - Mensagem recebida: " + mensagemJson);
+        Thread.sleep(5000); // opcional: tempo para visualização no Kafdrop
+        try {
+            PartidaRequestDto dto = objectMapper.readValue(mensagemJson, PartidaRequestDto.class);
+            partidaService.salvar(dto);
+            System.out.println(" verificação: Partida salva com sucesso!");
+        } catch (Exception e) {
+            System.err.println(" Erro ao processar partida. Enviando para retry/DLT se necessário: " + e.getMessage());
+            throw e; // importante: permite que o errohandler atue
+        }
     }
+    @KafkaListener(
+            topics = "${spring.kafka.topic.partida}.DLT",
+            groupId = "grupo-partida-dlt"
+    )
+    public void reprocessarMensagemDLT(String mensagemJson) {
+        System.err.println(" Reprocessando mensagem da DLT: " + mensagemJson);
+        try {
+            // Validação prévia antes de reenviar
+            PartidaRequestDto dto = objectMapper.readValue(mensagemJson, PartidaRequestDto.class);
+            partidaService.validarRegrasDeNegocio(dto);
 
+            partidaProducer.enviarMensagem(mensagemJson);
+            System.out.println(" verificação: Mensagem reenviada para o tópico principal com sucesso!");
+        } catch (Exception e) {
+            System.err.println(" Ainda inválida. " +
+                    "Não reprocessada faça chamada endpoint reprocessamento/dlt atualizar fila: " + e.getMessage());
 
+            // Aqui você pode persistir a falha ou apenas logar.
+        }
     }
-    @KafkaListener(topics = "${spring.kafka.topic.partida}.DLT", groupId = "grupo-partida-dlt")
-    public void consumirDlt(String mensagem) {
-        System.err.println(" Atenção Mensagem falhou e foi enviada para a DLT: " + mensagem);
-    }
-
-
-
-
-
-
-
 }

--- a/src/main/java/br/com/meli/apipartidafutebol/controller/ReprocessamentoController.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/controller/ReprocessamentoController.java
@@ -1,0 +1,39 @@
+package br.com.meli.apipartidafutebol.controller;
+
+import br.com.meli.apipartidafutebol.integration.PartidaProducer;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.springframework.web.bind.annotation.*;
+import java.time.Duration;
+import java.util.Collections;
+
+@RestController
+@RequestMapping("/reprocessamento")
+public class ReprocessamentoController {
+    private final PartidaProducer partidaProducer;
+    private final ConsumerFactory<String, String> consumerFactory;
+    public ReprocessamentoController(PartidaProducer partidaProducer, ConsumerFactory<String, String> consumerFactory) {
+        this.partidaProducer = partidaProducer;
+        this.consumerFactory = consumerFactory;
+    }
+    @PostMapping("/dlt")
+    public String reprocessarMensagensDLT() {
+        String topicDLT = "cadastro-partida.DLT";
+        try (Consumer<String, String> consumer = consumerFactory.createConsumer("grupo-partida-dlt-reprocesso", "")) {
+            consumer.subscribe(Collections.singletonList(topicDLT));
+            var registros = consumer.poll(Duration.ofSeconds(5));
+            if (registros.isEmpty()) {
+                return "Nenhuma mensagem na DLT para reprocessar.";
+            }
+            registros.forEach(record -> {
+                String mensagemJson = record.value();
+                System.out.println(" repetir Reenviando mensagem da DLT: " + mensagemJson);
+                partidaProducer.enviarMensagem(mensagemJson);
+            });
+            return registros.count() + " mensagens reprocessadas com sucesso!";
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "Erro ao reprocessar mensagens: " + e.getMessage();
+        }
+    }
+}

--- a/src/main/java/br/com/meli/apipartidafutebol/service/PartidaService.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/service/PartidaService.java
@@ -1,6 +1,5 @@
 package br.com.meli.apipartidafutebol.service;
-import br.com.meli.apipartidafutebol.dto.PartidaRequestDto;
-import br.com.meli.apipartidafutebol.dto.PartidaResponseDto;
+import br.com.meli.apipartidafutebol.dto.*;
 import br.com.meli.apipartidafutebol.exception.*;
 import br.com.meli.apipartidafutebol.model.Clube;
 import br.com.meli.apipartidafutebol.model.Estadio;
@@ -19,7 +18,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import br.com.meli.apipartidafutebol.dto.FiltroPartidaRequestDto;
 import br.com.meli.apipartidafutebol.specification.PartidaSpecification;
 
 
@@ -91,6 +89,13 @@ public class PartidaService {
     private Estadio buscarEstadio(Long id) {
         return estadioRepository.findById(id)
                 .orElseThrow(() -> new EstadioNaoEncontradoException("Estádio não encontrado."));
+    }
+
+    public void validarRegrasDeNegocio(PartidaRequestDto dto) {
+        Clube mandante = buscarClube(dto.getClubeMandanteId(), "mandante");
+        Clube visitante = buscarClube(dto.getClubeVisitanteId(), "visitante");
+        Estadio estadio = buscarEstadio(dto.getEstadioId());
+        validarRegrasDeNegocio(mandante, visitante, estadio, dto.getDataHora());
     }
 
     private void validarRegrasDeNegocio(Clube mandante, Clube visitante, Estadio estadio, LocalDateTime dataHora) {


### PR DESCRIPTION
Principais alterações nesta branch
- Implementação da classe `PartidaProducer` para publicar mensagens JSON no Kafka
- Criação do `PartidaConsumer` com tratamento de exceções e ativação de DLT
-  Configuração de `DefaultErrorHandler` com backoff exponencial
-  Tópico DLT tratado automaticamente via Spring Kafka
- Adição de endpoint `POST /reprocessar/dlt` para reenviar mensagens da DLT ao tópico principal
-  Ajustes em `application.properties` com configuração de consumer e producer
-  Docker Compose atualizado com Kafka, Zookeeper e Kafdrop
- Logs informativos para facilitar visualização e debug
- Testes manuais com banco fora do ar e simulação de falhas
---
### :Como testar
1. Executar `docker-compose up` para subir Kafka/Zookeeper/Kafdrop
2. Iniciar a aplicação Spring Boot (`main` ou pela IDE)
3. Enviar uma partida com `POST /partidas/publicar`
4. Simular falha desligando o banco — ver mensagem ir para DLT
5. Reprocessar com `POST /reprocessar/dlt` após reativar o banco
6. Verificar persistência e logs no console/Kafdrop
