### PR TITLE
feat: agendamento automático para reprocessar mensagens da DLT com @S…

### DIFF
--- a/src/main/java/br/com/meli/apipartidafutebol/ApiPartidaFutebolApplication.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/ApiPartidaFutebolApplication.java
@@ -3,9 +3,11 @@ package br.com.meli.apipartidafutebol;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableKafka
 @SpringBootApplication
+@EnableScheduling
 public class ApiPartidaFutebolApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/br/com/meli/apipartidafutebol/config/ScheduledReprocessadorDLT.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/config/ScheduledReprocessadorDLT.java
@@ -1,0 +1,41 @@
+package br.com.meli.apipartidafutebol.config;
+
+import br.com.meli.apipartidafutebol.integration.PartidaProducer;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import java.time.Duration;
+import java.util.Collections;
+@Component
+public class ScheduledReprocessadorDLT {
+    private final ConsumerFactory<String, String> consumerFactory;
+    private final PartidaProducer partidaProducer;
+    public ScheduledReprocessadorDLT(ConsumerFactory<String, String> consumerFactory,
+                                     PartidaProducer partidaProducer) {
+        this.consumerFactory = consumerFactory;
+        this.partidaProducer = partidaProducer;
+    }
+    @Scheduled(cron = "0 */5 * * * *", zone = "America/Sao_Paulo") // A cada 5 min
+    public void reprocessarAutomaticamente() {
+        String dltTopic = "cadastro-partida.DLT";
+        System.out.println(" Verificando mensagens na DLT para reprocessar...");
+        try (Consumer<String, String> consumer = consumerFactory.createConsumer("grupo-dlt-scheduler", "")) {
+            consumer.subscribe(Collections.singletonList(dltTopic));
+            var registros = consumer.poll(Duration.ofSeconds(5));
+            if (registros.isEmpty()) {
+                System.out.println(" Nenhuma mensagem DLT para reprocessar.");
+                return;
+            }
+            for (ConsumerRecord<String, String> record : registros) {
+                String mensagem = record.value();
+                System.out.println(" Reenviando DLT para tópico principal: " + mensagem);
+                partidaProducer.enviarMensagem(mensagem);
+            }
+            System.out.println(" Reprocessamento automático concluído: " + registros.count() + " mensagens.");
+        } catch (Exception e) {
+            System.err.println(" Erro ao reprocessar DLT: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
reprocessamento automático de mensagens da Dead Letter Topic (DLT) usando a anotação @Scheduled com expressão cron.

@EnableScheduling incluido anotacao na classe aplication ativando agendamento na minha api.
Criação da classe ScheduledReprocessadorDLT, responsável por:
Ler mensagens do tópico cadastro-partida.DLT
Reenviá-las automaticamente para o tópico principal (cadastro-partida)
Executar o processo periodicamente conforme agendamento definido
Integração com ConsumerFactory e PartidaProducer
Log informativo durante o reprocessamento
Reprocessamento mantido com reprocessamento manual via ReprocessamentoController.