### PR TITLE
feat: integração com Gmail via SMTP para envio agendado de relatorio …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,10 @@
             <artifactId>spring-kafka</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.30</version> <!-- ou a mais recente -->

--- a/src/main/java/br/com/meli/apipartidafutebol/config/RelatorioPartidasScheduler.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/config/RelatorioPartidasScheduler.java
@@ -1,0 +1,50 @@
+package br.com.meli.apipartidafutebol.config;
+
+import br.com.meli.apipartidafutebol.dto.PartidaResponseDto;
+import br.com.meli.apipartidafutebol.service.EmailService;
+import br.com.meli.apipartidafutebol.service.PartidaService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.stream.Collectors;
+@Component
+public class RelatorioPartidasScheduler {
+    @Autowired
+    private PartidaService partidaService;
+    @Autowired
+    private EmailService emailService;
+
+    @Value("${relatorio.email.destinatario}")
+    private String destinatario;
+
+
+    // Executa todos os dias às 08h00 da manhã (horário de São Paulo)
+    @Scheduled(cron = "0 0 8 * * *", zone = "America/Sao_Paulo")
+    public void enviarRelatorioPartidasAgendadas() {
+        List<PartidaResponseDto> partidas = partidaService.listarTodas();
+        if (partidas.isEmpty()) {
+            System.out.println(":caixa_de_correio_vazia: Nenhuma partida cadastrada no momento.");
+            return;
+        }
+        String corpoEmail = gerarCorpoRelatorio(partidas);
+        String assunto = ":gráfico_de_barras: Relatório Diário de Partidas Cadastradas";
+        try {
+            emailService.enviarRelatorioPartidas(destinatario, assunto, corpoEmail);
+            System.out.println(":marca_de_verificação_branca: Relatório de partidas enviado com sucesso.");
+        } catch (Exception e) {
+            System.err.println(":x_vermelho: Erro ao enviar relatório de partidas: " + e.getMessage());
+        }
+    }
+    private String gerarCorpoRelatorio(List<PartidaResponseDto> partidas) {
+        return partidas.stream()
+                .map(p -> String.format("<li><strong>ID:</strong> %d | <strong>Data:</strong> %s |" +
+                                " <strong>Mandante:</strong> %s | <strong>Visitante:</strong> %s</li>",
+                        p.getId(),
+                        p.getDataHora(),
+                        p.getClubeMandante(),
+                        p.getClubeVisitante()))
+                .collect(Collectors.joining("", "<ul>", "</ul>"));
+    }
+}

--- a/src/main/java/br/com/meli/apipartidafutebol/controller/EmailController.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/controller/EmailController.java
@@ -1,0 +1,17 @@
+package br.com.meli.apipartidafutebol.controller;
+
+import br.com.meli.apipartidafutebol.config.RelatorioPartidasScheduler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+@RestController
+@RequestMapping("/teste")
+public class EmailController {
+    @Autowired
+    private RelatorioPartidasScheduler scheduler;
+    @GetMapping("/enviar-relatorio")
+    public ResponseEntity<String> testarEnvioManual() {
+        scheduler.enviarRelatorioPartidasAgendadas();
+        return ResponseEntity.ok(":marca_de_verificação_branca: Relatório de partidas enviado manualmente.");
+    }
+}

--- a/src/main/java/br/com/meli/apipartidafutebol/service/EmailService.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/service/EmailService.java
@@ -1,0 +1,32 @@
+package br.com.meli.apipartidafutebol.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+@Service
+public class EmailService {
+    @Autowired
+    private JavaMailSender mailSender;
+    @Autowired
+    private Environment env;
+    public void enviarRelatorioPartidas(String destinatario, String assunto, String corpoHtml) throws MessagingException {
+        if (corpoHtml == null || corpoHtml.isBlank()) {
+            throw new IllegalArgumentException("O conteúdo do relatório está vazio.");
+        }
+        MimeMessage mensagem = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(mensagem, true, "UTF-8");
+        helper.setTo(destinatario);
+        helper.setSubject(assunto);
+        helper.setText(corpoHtml, true); // true = envia como HTML
+        // Define o remetente se necessário
+        String remetente = env.getProperty("spring.mail.username");
+        if (remetente != null && !remetente.isBlank()) {
+            helper.setFrom(remetente);
+        }
+        mailSender.send(mensagem);
+    }
+}

--- a/src/main/java/br/com/meli/apipartidafutebol/service/PartidaService.java
+++ b/src/main/java/br/com/meli/apipartidafutebol/service/PartidaService.java
@@ -11,6 +11,8 @@ import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -148,6 +150,12 @@ public class PartidaService {
     public Page<PartidaResponseDto> filtrarPartidas(FiltroPartidaRequestDto filtro, Pageable pageable) {
         Specification<Partida> specification = PartidaSpecification.filtrar(filtro);
         return partidaRepository.findAll(specification, pageable).map(PartidaResponseDto::new);
+    }
+
+    public List<Partida> buscarPartidasAgendadas() {
+        return partidaRepository.findAll().stream()
+                .filter(partida -> partida.getDataHora().isAfter(LocalDate.now().atStartOfDay()))
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,3 +23,13 @@ spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.S
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.retries=0
+# SMTP do Gmail
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=androamafreitas@gmail.com
+spring.mail.password= senha gmail
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.protocol=smtp
+spring.mail.default-encoding=UTF-8
+relatorio.email.destinatario=androamafreitas@gmail.com


### PR DESCRIPTION
PR implementa o envio automático de relatórios de partidas via e-mail utilizando o agendamento diário com @Scheduled e envio pelo SMTP do Gmail.
- Configuração de EmailService com JavaMailSender
- Classe RelatorioPartidasScheduler para execução agendada
-  Integração segura com conta Gmail via App Password
-  Testado com sucesso envio automático às 08:00 (cron)
- Adicionado endpoint manual interativo que permite enviar relatório sob demanda .